### PR TITLE
0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,21 +262,21 @@ var options = {
 }
 ```
 
-- **verificationURL**: the URL for the user to click to verify their account. `${URL}` determines where the randomly generated part of the URL goes - it must be included.
-- **URLLength**: the length of the randomly-generated string.
+- **verificationURL**: the URL for the user to click to verify their account. `${URL}` determines where the randomly generated part of the URL goes, and is needed. Required.
+- **URLLength**: the length of the randomly-generated string. Must be a positive integer. Required.
 
 - **persistentUserModel**: the Mongoose Model for the persistent user.
 - **tempUserModel**: the Mongoose Model for the temporary user. you can generate the model by using `generateTempUserModel` and passing it the persistent User model you have defined, or you can define your own model in a separate file and pass it as an option in `configure` instead.
 - **tempUserCollection**: the name of the MongoDB collection for temporary users.
-- **emailFieldName**: the field name for the user's email. if the field is nested within another object(s), use dot notation to access it, e.g. `{local: {email: ...}}` would use `'local.email'`.
-- **passwordFieldName**: the field name for the user's password. If the field is nested within another object(s), use dot notation to access it (see above).
-- **URLFieldName**: the field name for the randomly-generated URL.
-- **expirationTime**: the amount of time that the temporary user will be kept in collection, measured in seconds.
+- **emailFieldName**: the field name for the user's email. If the field is nested within another object(s), use dot notation to access it, e.g. `{local: {email: ...}}` would use `'local.email'`. Required.
+- **passwordFieldName**: the field name for the user's password. If the field is nested within another object(s), use dot notation to access it (see above). Required.
+- **URLFieldName**: the field name for the randomly-generated URL. Required.
+- **expirationTime**: the amount of time that the temporary user will be kept in collection, measured in seconds. Must be a positive integer. Required.
 
 - **transportOptions**: the options that will be passed to `nodemailer.createTransport`.
-- **verifyMailOptions**: the options that will be passed to `nodemailer.createTransport({...}).sendMail` when sending an email for verification. you must include `${URL}` somewhere in the `html` and/or `text` fields to put the URL in these strings.
+- **verifyMailOptions**: the options that will be passed to `nodemailer.createTransport({...}).sendMail` when sending an email for verification. You must include `${URL}` somewhere in the `html` and/or `text` fields to put the URL in these strings.
 - **sendConfirmationEmail**: send an email upon the user verifiying their account to notify them of verification.
-- **confirmMailOptions**: the options that will be passed to `nodemailer.createTransport({...}).sendMail` when sending an email to notify the user that their account has been verified. you must include `${URL}` somewhere in the `html` and/or `text` fields to put the URL in these strings.
+- **confirmMailOptions**: the options that will be passed to `nodemailer.createTransport({...}).sendMail` when sending an email to notify the user that their account has been verified. You must include `${URL}` somewhere in the `html` and/or `text` fields to put the URL in these strings.
 
 - **hashingFunction**: the function that hashes passwords. Must take four parameters `password, tempUserData, insertTempUser, callback` and return `insertTempUser(hash, tempUserData, callback)`.
 

--- a/README.md
+++ b/README.md
@@ -175,11 +175,13 @@ nev.resendVerificationEmail(email, function(err, userFound) {
 
 To see a fully functioning example that uses Express as the backend, check out the [**examples section**](https://github.com/SaintDako/node-email-verification/tree/master/examples/express).
 
-## API
-### `configure(options)`
-Changes the default configuration by passing an object of options; see the section below for a list of all options.
+**NEV supports Bluebird's PromisifyAll!** Check out the examples section for that too.
 
-### `generateTempUserModel(UserModel)`
+## API
+### `configure(optionsToConfigure, callback(err, options))`
+Changes the default configuration by passing an object of options to configure (`optionsToConfigure`); see the section below for a list of all options. `options` will be the result of the configuration, with the default values specified below if they were not given. If there are no errors, `err` is `null`.
+
+### `generateTempUserModel(UserModel, callback(err, tempUserModel))`
 Generates a Mongoose Model for the temporary user based off of `UserModel`, the persistent user model. The temporary model is essentially a duplicate of the persistent model except that it has the field `{GENERATED_VERIFYING_URL: String}` for the randomly generated URL by default (the field name can be changed in the options). If the persistent model has the field `createdAt`, then an expiration time (`expires`) is added to it with a default value of 24 hours; otherwise, the field is created as such:
 
 ```javascript
@@ -193,6 +195,8 @@ Generates a Mongoose Model for the temporary user based off of `UserModel`, the 
     ...
 }
 ```
+
+`tempUserModel` is the Mongoose model that is created for the temporary user. If there are no errors, `err` is `null`.
 
 Note that `createdAt` will not be transferred to persistent storage (yet?).
 

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -33,10 +33,8 @@ nev.configure({
   transportOptions: {
     service: 'Gmail',
     auth: {
-      // user: 'yoursupercoolemailyeah@gmail.com',
-      // pass: 'yoursupersecurepassword'
-      user: 'numbersjsinfo@gmail.com',
-      pass: 'j9IhEJXr'
+      user: 'yoursupercoolemailyeah@gmail.com',
+      pass: 'yoursupersecurepassword'
     }
   },
 

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -33,8 +33,10 @@ nev.configure({
   transportOptions: {
     service: 'Gmail',
     auth: {
-      user: 'yoursupercoolemailyeah@gmail.com',
-      pass: 'yoursupersecurepassword'
+      // user: 'yoursupercoolemailyeah@gmail.com',
+      // pass: 'yoursupersecurepassword'
+      user: 'numbersjsinfo@gmail.com',
+      pass: 'j9IhEJXr'
     }
   },
 
@@ -46,7 +48,7 @@ nev.configure({
     return;
   }
 
-  console.log('configured!');
+  console.log('configured: ' + (typeof options === 'object'));
 });
 
 nev.generateTempUserModel(User, function(err, tempUserModel) {
@@ -55,7 +57,7 @@ nev.generateTempUserModel(User, function(err, tempUserModel) {
     return;
   }
 
-  console.log('generated temp user model!');
+  console.log('generated temp user model: ' + (typeof tempUserModel === 'function'));
 });
 
 
@@ -80,7 +82,7 @@ app.post('/', function(req, res) {
 
     nev.createTempUser(newUser, function(err, newTempUser) {
       if (err) {
-        return res.status(404).send('FAILED');
+        return res.status(404).send('ERROR: creating temp user FAILED');
       }
 
       // new user created
@@ -88,8 +90,12 @@ app.post('/', function(req, res) {
         var URL = newTempUser[nev.options.URLFieldName];
 
         nev.sendVerificationEmail(email, URL, function(err, info) {
+          if (err) {
+            return res.status(404).send('ERROR: sending verification email FAILED');
+          }
           res.json({
-            msg: 'An email has been sent to you. Please check it to verify your account.'
+            msg: 'An email has been sent to you. Please check it to verify your account.',
+            info: info
           });
         });
 
@@ -104,6 +110,9 @@ app.post('/', function(req, res) {
   // resend verification button was clicked
   } else {
     nev.resendVerificationEmail(email, function(err, userFound) {
+      if (err) {
+        return res.status(404).send('ERROR: resending verification email FAILED');
+      }
       if (userFound) {
         res.json({
           msg: 'An email has been sent to you, yet again. Please check it to verify your account.'
@@ -124,15 +133,20 @@ app.get('/email-verification/:URL', function(req, res) {
 
   nev.confirmTempUser(url, function(err, user) {
     if (user) {
-      nev.sendConfirmationEmail(user['email'], function(err, info) {
-        res.send('You have been confirmed!');
+      nev.sendConfirmationEmail(user.email, function(err, info) {
+        if (err) {
+          return res.status(404).send('ERROR: sending confirmation email FAILED');
+        }
+        res.json({
+          msg: 'CONFIRMED!',
+          info: info
+        });
       });
     } else {
-      res.status(404).send('FAILED');
+      return res.status(404).send('ERROR: confirming temp user FAILED');
     }
   });
 });
-
 
 app.listen(8000);
 console.log('Express & NEV example listening on 8000...');

--- a/examples/express/server_promisified.js
+++ b/examples/express/server_promisified.js
@@ -3,7 +3,8 @@ var express = require('express'),
   app = express(),
   mongoose = require('mongoose'),
   bcrypt = require('bcryptjs'),
-  nev = require('../../index')(mongoose);
+  Promise = require('bluebird'),
+  nev = Promise.promisifyAll(require('../../index')(mongoose));
 mongoose.connect('mongodb://localhost/YOUR_DB');
 
 // our persistent user model
@@ -25,11 +26,11 @@ myHasher = function(password, tempUserData, insertTempUser, callback) {
 };
 
 // NEV configuration =====================
-nev.configure({
+nev.configureAsync({
   persistentUserModel: User,
   expirationTime: 600, // 10 minutes
 
-  verificationURL: 'http://localhost:8000/email-verification/${URL}',
+  verificationURL: 'http://localhost:9000/email-verification/${URL}',
   transportOptions: {
     service: 'Gmail',
     auth: {
@@ -40,22 +41,17 @@ nev.configure({
 
   hashingFunction: myHasher,
   passwordFieldName: 'pw',
-}, function(err, options) {
-  if (err) {
-    console.log(err);
-    return;
-  }
-
-  console.log('configured!');
-});
-
-nev.generateTempUserModel(User, function(err, tempUserModel) {
-  if (err) {
-    console.log(err);
-    return;
-  }
-
-  console.log('generated temp user model!');
+})
+.then(function(options) {
+  console.log('configured: ' + (typeof options === 'object'));
+  return nev.generateTempUserModelAsync(User);
+})
+.then(function(tempUserModel) {
+  console.log('generated temp user model: ' + (typeof tempUserModel === 'function'));
+})
+.catch(function(err) {
+  console.log('ERROR!');
+  console.log(err);
 });
 
 
@@ -78,20 +74,11 @@ app.post('/', function(req, res) {
       pw: pw
     });
 
-    nev.createTempUser(newUser, function(err, newTempUser) {
-      if (err) {
-        return res.status(404).send('FAILED');
-      }
-
-      // new user created
+    nev.createTempUserAsync(newUser)
+    .then(function(newTempUser) {
       if (newTempUser) {
         var URL = newTempUser[nev.options.URLFieldName];
-
-        nev.sendVerificationEmail(email, URL, function(err, info) {
-          res.json({
-            msg: 'An email has been sent to you. Please check it to verify your account.'
-          });
-        });
+        return nev.sendVerificationEmailAsync(email, URL);
 
       // user already exists in temporary collection!
       } else {
@@ -99,11 +86,20 @@ app.post('/', function(req, res) {
           msg: 'You have already signed up. Please check your email to verify your account.'
         });
       }
+    })
+    .then(function(info) {
+      res.json({
+        msg: 'An email has been sent to you. Please check it to verify your account.'
+      });
+    })
+    .catch(function() {
+      return res.status(404).send('FAILED');
     });
 
   // resend verification button was clicked
   } else {
-    nev.resendVerificationEmail(email, function(err, userFound) {
+    nev.resendVerificationEmailAsync(email)
+    .then(function(userFound) {
       if (userFound) {
         res.json({
           msg: 'An email has been sent to you, yet again. Please check it to verify your account.'
@@ -113,6 +109,9 @@ app.post('/', function(req, res) {
           msg: 'Your verification code has expired. Please sign up again.'
         });
       }
+    })
+    .catch(function() {
+      return res.status(404).send('FAILED');
     });
   }
 });
@@ -122,17 +121,22 @@ app.post('/', function(req, res) {
 app.get('/email-verification/:URL', function(req, res) {
   var url = req.params.URL;
 
-  nev.confirmTempUser(url, function(err, user) {
+  nev.confirmTempUserAsync(url)
+  .then(function(user) {
     if (user) {
-      nev.sendConfirmationEmail(user['email'], function(err, info) {
-        res.send('You have been confirmed!');
-      });
+      nev.sendConfirmationEmailAsync(user['email']);
     } else {
       res.status(404).send('FAILED');
     }
+  })
+  .then(function(info) {
+    res.send('You have been confirmed!');
+  })
+  .catch(function() {
+    res.status(404).send('FAILED');
   });
 });
 
 
-app.listen(8000);
-console.log('Express & NEV example listening on 8000...');
+app.listen(9000);
+console.log('Express & NEV PROMISIFIED! example listening on 9000...');

--- a/examples/express/server_promisified.js
+++ b/examples/express/server_promisified.js
@@ -89,7 +89,8 @@ app.post('/', function(req, res) {
     })
     .then(function(info) {
       res.json({
-        msg: 'An email has been sent to you. Please check it to verify your account.'
+        msg: 'An email has been sent to you. Please check it to verify your account.',
+        info: info
       });
     })
     .catch(function() {
@@ -111,7 +112,7 @@ app.post('/', function(req, res) {
       }
     })
     .catch(function() {
-      return res.status(404).send('FAILED');
+      return res.status(404).send('ERROR: resending verification email FAILED');
     });
   }
 });
@@ -124,13 +125,16 @@ app.get('/email-verification/:URL', function(req, res) {
   nev.confirmTempUserAsync(url)
   .then(function(user) {
     if (user) {
-      nev.sendConfirmationEmailAsync(user['email']);
+      nev.sendConfirmationEmailAsync(user.email);
     } else {
-      res.status(404).send('FAILED');
+      res.status(404).send('ERROR: confriming temp user FAILED');
     }
   })
   .then(function(info) {
-    res.send('You have been confirmed!');
+    res.json({
+      msg: 'You have been confirmed!',
+      info: info
+    });
   })
   .catch(function() {
     res.status(404).send('FAILED');

--- a/index.js
+++ b/index.js
@@ -232,8 +232,9 @@ module.exports = function(mongoose) {
     var r = /\$\{URL\}/g;
 
     // inject newly-created URL into the email's body and FIRE
+    // stringify --> parse is used to deep copy
     var URL = options.verificationURL.replace(r, url),
-      mailOptions = options.verifyMailOptions;
+      mailOptions = JSON.parse(JSON.stringify(options.verifyMailOptions));
 
     mailOptions.to = email;
     mailOptions.html = mailOptions.html.replace(r, URL);
@@ -250,7 +251,7 @@ module.exports = function(mongoose) {
    * @param {function} callback - the callback to pass to Nodemailer's transporter
    */
   var sendConfirmationEmail = function(email, callback) {
-    var mailOptions = options.confirmMailOptions;
+    var mailOptions = JSON.parse(JSON.stringify(options.confirmMailOptions));
     mailOptions.to = email;
     transporter.sendMail(mailOptions, callback);
   };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,15 @@ var randtoken = require('rand-token'),
 
 module.exports = function(mongoose) {
 
+  var isPositiveInteger = function(x) {
+    return ((parseInt(x, 10) === x) && (x >= 0));
+  };
+
+  var createOptionError = function(optionName, optionValue, expectedType) {
+    return new TypeError('Expected ' + optionName + ' to be a ' + expectedType + ', got ' + 
+      typeof optionValue);
+  };
+
   /**
    * Retrieve a nested value of an object given a string, using dot notation.
    *
@@ -86,6 +95,46 @@ module.exports = function(mongoose) {
       }
     }
     transporter = nodemailer.createTransport(options.transportOptions);
+
+    var err;
+
+    if (typeof options.verificationURL !== 'string') {
+      err = err || createOptionError('verificationURL', options.verificationURL, 'string');
+    } else if (options.verificationURL.indexOf('${URL}') === -1) {
+      err = err || new Error('Verification URL does not contain ${URL}');
+    }
+
+    if (typeof options.URLLength !== 'number') {
+      err = err || createOptionError('URLLength', options.URLLength, 'number');
+    } else if (!isPositiveInteger(options.URLLength)) {
+      err = err || new Error('URLLength must be a positive integer');
+    }
+
+    if (typeof options.tempUserCollection !== 'string') {
+      err = err || createOptionError('tempUserCollection', options.tempUserCollection, 'string');
+    }
+
+    if (typeof options.emailFieldName !== 'string') {
+      err = err || createOptionError('emailFieldName', options.emailFieldName, 'string');
+    }
+
+    if (typeof options.passwordFieldName !== 'string') {
+      err = err || createOptionError('passwordFieldName', options.passwordFieldName, 'string');
+    }
+
+    if (typeof options.URLFieldName !== 'string') {
+      err = err || createOptionError('URLFieldName', options.URLFieldName, 'string');
+    }
+
+    if (typeof options.expirationTime !== 'number') {
+      err = err || createOptionError('expirationTime', options.expirationTime, 'number');
+    } else if (!isPositiveInteger(options.expirationTime)) {
+      err = err || new Error('expirationTime must be a positive integer');
+    }
+
+    if (err) {
+      return callback(err, null);
+    }
 
     return callback(null, options);
   };

--- a/index.js
+++ b/index.js
@@ -79,13 +79,15 @@ module.exports = function(mongoose) {
    * @func configure
    * @param {object} o - options to be changed
    */
-  var configure = function(o) {
-    for (var key in o) {
-      if (o.hasOwnProperty(key)) {
-        options[key] = o[key];
+  var configure = function(optionsToConfigure, callback) {
+    for (var key in optionsToConfigure) {
+      if (optionsToConfigure.hasOwnProperty(key)) {
+        options[key] = optionsToConfigure[key];
       }
     }
     transporter = nodemailer.createTransport(options.transportOptions);
+
+    return callback(null, options);
   };
 
 
@@ -98,7 +100,10 @@ module.exports = function(mongoose) {
    * @param {object} User - the persistent User model.
    * @return {object} the temporary user model
    */
-  var generateTempUserModel = function(User) {
+  var generateTempUserModel = function(User, callback) {
+    if (!User) {
+      return callback(new TypeError('Persistent user model undefined.'), null);
+    }
     var tempUserSchemaObject = {}, // a copy of the schema
       tempUserSchema;
 
@@ -124,7 +129,7 @@ module.exports = function(mongoose) {
 
     options.tempUserModel = mongoose.model(options.tempUserCollection, tempUserSchema);
 
-    return mongoose.model(options.tempUserCollection);
+    return callback(null, mongoose.model(options.tempUserCollection));
   };
 
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "jshint": "^2.8.0",
     "jshint-stylish": "^2.0.1",
     "mocha": "*",
-    "nodemailer-stub-transport": "^1.0.0"
+    "nodemailer-stub-transport": "^1.0.0",
+    "bluebird": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-verification",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Verify email sign-up using MongoDB.",
   "main": "index.js",
   "scripts": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,15 +6,19 @@ var stubTransport = require('nodemailer-stub-transport');
 var user = require('../examples/express/app/userModel'); // sample user schema
 mongoose.connect('mongodb://localhost/test_database'); // needed for testing
 
-
-nev.generateTempUserModel(user);
-nev.configure({
-  transportOptions: stubTransport(),
-  persistentUserModel: user,
-  passwordFieldName: 'pw',
-});
-
 describe('config & set up tests', function() {
+
+  it('Generates a temp user model', function(done) {
+    nev.generateTempUserModel(user, done);
+  });
+
+  it('Configures the options', function(done) {
+    nev.configure({
+      transportOptions: stubTransport(),
+      persistentUserModel: user,
+      passwordFieldName: 'pw',
+    }, done);
+  });
 
   it('Tests the option object', function() {
     assert.typeOf(nev.options.URLLength, 'number', 'URL Length must be a number');

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,4 +1,3 @@
-var assert = require('chai').assert;
 var should = require('chai').should();
 var mongoose = require('mongoose');
 var nev = require('../index')(mongoose);
@@ -8,22 +7,59 @@ mongoose.connect('mongodb://localhost/test_database'); // needed for testing
 
 describe('config & set up tests', function() {
 
+  var tempUserModel;
+
   it('Generates a temp user model', function(done) {
-    nev.generateTempUserModel(user, done);
+    nev.generateTempUserModel(user, function(err, generatedTempUserModel) {
+      tempUserModel = generatedTempUserModel;
+      done();
+    });
   });
 
-  it('Configures the options', function(done) {
-    nev.configure({
-      transportOptions: stubTransport(),
-      persistentUserModel: user,
-      passwordFieldName: 'pw',
-    }, done);
-  });
+  describe('Test configuration error throwing', function() {
 
-  it('Tests the option object', function() {
-    assert.typeOf(nev.options.URLLength, 'number', 'URL Length must be a number');
-    assert.typeOf(nev.options.expirationTime, 'number', 'Expiration time must be a number');
-    assert.typeOf(nev.options.verificationURL, 'string', 'URL for verification must be a string');
+    var defaultOptions;
+
+    before(function() {
+      defaultOptions = JSON.parse(JSON.stringify(nev.options));
+    });
+
+
+    var tests = [
+      {field: 'verificationURL', wrongValue: 100, reason: 'type'},
+      {field: 'verificationURL', wrongValue: 'someurl', reason: 'value'},
+      {field: 'URLLength', wrongValue: 'str', reason: 'type'},
+      {field: 'URLLength', wrongValue: -20, reason: 'value'},
+      {field: 'URLLength', wrongValue: 5.5, reason: 'value'},
+      {field: 'tempUserCollection', wrongValue: null, reason: 'type'},
+      {field: 'emailFieldName', wrongValue: [], reason: 'type'},
+      {field: 'passwordFieldName', wrongValue: {}, reason: 'type'},
+      {field: 'URLFieldName', wrongValue: 5.5, reason: 'type'},
+      {field: 'expirationTime', wrongValue: '100', reason: 'type'},
+      {field: 'expirationTime', wrongValue: -42, reason: 'value'},
+      {field: 'expirationTime', wrongValue: 4.2, reason: 'value'},
+    ];
+
+    tests.forEach(function(test) {
+      it('should throw an error for invalid ' + test.field + ' ' + test.reason, function(done) {
+        var optionsToConfigure = {};
+        optionsToConfigure[test.field] = test.wrongValue;
+        nev.configure(optionsToConfigure, function(err, options) {
+          should.exist(err);
+          should.not.exist(options);
+          done();
+        });
+      });
+    });
+
+    after(function(done) {
+      var newOptions = JSON.parse(JSON.stringify(defaultOptions));
+      newOptions.tempUserModel = tempUserModel;
+      newOptions.transportOptions = stubTransport();
+      newOptions.persistentUserModel = user;
+      newOptions.passwordFieldName = 'pw';
+      nev.configure(newOptions, done);
+    });
   });
 
 });


### PR DESCRIPTION
this actually contains a big bug fix - I removed `JSON.parse(JSON.stringifiy(options.mailOptions)` before which actually made a deep copy of the `mailOptions` object. that's what we want, since we change the `text` field to contain the URL verification route (with `${URL}` in it) and then replace that with the URL for the user. however, by removing the deep copy, what happened was, e.g.

- user signs up, is assigned URL `somerandomurl`
- `mailOptions.text = 'visit localhost:8000/${URL}'` --> `mailOptions.text = ''visit localhost:8000/somerandomurl'`
- different user signs up, is assigned URL `NOTTHESAMEURL`
- `mailOptions.text` tries to replace `${URL}` with `'NOTTHESAMEURL'` but we actually didn't deep copy `mailOptions` so it's what it was before!
- email with old URL is sent

will add more commits with the throwing errors for options (for #21).